### PR TITLE
feat: add support for PITR-lite backups

### DIFF
--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -400,7 +400,7 @@ class Instance(object):
         )
         return page_iter
 
-    def backup(self, backup_id, database="", expire_time=None):
+    def backup(self, backup_id, database="", expire_time=None, version_time=None):
         """Factory to create a backup within this instance.
 
         :type backup_id: str
@@ -415,13 +415,29 @@ class Instance(object):
         :param expire_time:
             Optional. The expire time that will be used when creating the backup.
             Required if the create method needs to be called.
+
+        :type version_time: :class:`datetime.datetime`
+        :param version_time:
+            Optional. The version time that will be used to create the externally
+            consistent copy of the database. If not present, it is the same as
+            the `create_time` of the backup.
         """
         try:
             return Backup(
-                backup_id, self, database=database.name, expire_time=expire_time
+                backup_id,
+                self,
+                database=database.name,
+                expire_time=expire_time,
+                version_time=version_time,
             )
         except AttributeError:
-            return Backup(backup_id, self, database=database, expire_time=expire_time)
+            return Backup(
+                backup_id,
+                self,
+                database=database,
+                expire_time=expire_time,
+                version_time=version_time,
+            )
 
     def list_backups(self, filter_="", page_size=None):
         """List backups for the instance.

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -672,7 +672,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         backup_id = "backup_id" + unique_resource_id("_")
         expire_time = datetime.utcnow() + timedelta(days=3)
         expire_time = expire_time.replace(tzinfo=UTC)
-        version_time = datetime.utcnow() - timedelta(days=5)
+        version_time = datetime.utcnow() - timedelta(minutes=5)
         version_time = version_time.replace(tzinfo=UTC)
 
         # Create backup.
@@ -732,6 +732,12 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         operation = backup.create()
         self.to_delete.append(backup)
 
+        # Check metadata.
+        metadata = operation.metadata
+        self.assertEqual(backup.name, metadata.name)
+        self.assertEqual(self._db.name, metadata.database)
+        operation.result()
+
         # Check backup object.
         backup.reload()
         self.assertEqual(self._db.name, backup._database)
@@ -751,6 +757,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
 
     def test_create_backup_invalid_version_time_past(self):
         from datetime import datetime
+        from datetime import timedelta
         from pytz import UTC
 
         backup_id = "backup_id" + unique_resource_id("_")
@@ -772,6 +779,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
 
     def test_create_backup_invalid_version_time_future(self):
         from datetime import datetime
+        from datetime import timedelta
         from pytz import UTC
 
         backup_id = "backup_id" + unique_resource_id("_")
@@ -887,8 +895,8 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         instance = Config.INSTANCE
         expire_time_1 = datetime.utcnow() + timedelta(days=21)
         expire_time_1 = expire_time_1.replace(tzinfo=UTC)
-        version_time_1 = datetime.utcnow() - timedelta(days=5)
-        version_time_1 = version_time_1(tzinfo=UTC)
+        version_time_1 = datetime.utcnow() - timedelta(minutes=5)
+        version_time_1 = version_time_1.replace(tzinfo=UTC)
 
         backup1 = Config.INSTANCE.backup(
             backup_id_1,

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -273,12 +273,21 @@ class TestBackup(_BaseTest):
         api.create_backup.return_value = op_future
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        timestamp = self._make_timestamp()
+        version_timestamp = self._make_timestamp()
+        expire_timestamp = self._make_timestamp()
         backup = self._make_one(
-            self.BACKUP_ID, instance, database=self.DATABASE_NAME, expire_time=timestamp
+            self.BACKUP_ID,
+            instance,
+            database=self.DATABASE_NAME,
+            expire_time=expire_timestamp,
+            version_time=version_timestamp,
         )
 
-        backup_pb = Backup(database=self.DATABASE_NAME, expire_time=timestamp,)
+        backup_pb = Backup(
+            database=self.DATABASE_NAME,
+            expire_time=expire_timestamp,
+            version_time=version_timestamp,
+        )
 
         future = backup.create()
         self.assertIs(future, op_future)
@@ -437,6 +446,7 @@ class TestBackup(_BaseTest):
             name=self.BACKUP_NAME,
             database=self.DATABASE_NAME,
             expire_time=timestamp,
+            version_time=timestamp,
             create_time=timestamp,
             size_bytes=10,
             state=1,
@@ -452,6 +462,7 @@ class TestBackup(_BaseTest):
         self.assertEqual(backup.database, self.DATABASE_NAME)
         self.assertEqual(backup.expire_time, timestamp)
         self.assertEqual(backup.create_time, timestamp)
+        self.assertEqual(backup.version_time, timestamp)
         self.assertEqual(backup.size_bytes, 10)
         self.assertEqual(backup.state, Backup.State.CREATING)
         self.assertEqual(backup.referencing_databases, [])

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -266,6 +266,9 @@ class TestBackup(_BaseTest):
 
     def test_create_success(self):
         from google.cloud.spanner_admin_database_v1 import Backup
+        from datetime import datetime
+        from datetime import timedelta
+        from pytz import UTC
 
         op_future = object()
         client = _Client()
@@ -273,7 +276,8 @@ class TestBackup(_BaseTest):
         api.create_backup.return_value = op_future
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        version_timestamp = self._make_timestamp()
+        version_timestamp = datetime.utcnow() - timedelta(minutes=5)
+        version_timestamp = version_timestamp.replace(tzinfo=UTC)
         expire_timestamp = self._make_timestamp()
         backup = self._make_one(
             self.BACKUP_ID,


### PR DESCRIPTION
Adds support for setting and getting the version time of a backup. This is part of the PITR-lite feature.